### PR TITLE
Add docker run parameters

### DIFF
--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -23,8 +23,17 @@
 #@ def _get_file_upload_path(section):
 #@ return getattr(section,"upload_path","TestResults")
 #@ end
+---
+#@ def _get_image_run_args(section):
+#@ args ="";
+#@ for arg in getattr(section,"image_run_args",[]):
+#@  args += "\"{}\" ".format(arg)
+#@ end
+#@ return args
+#@ end
 
 ---
 #@ cfg = struct.make(get_cache_type = _get_cache_type,
 #@ get_required_docker_cache_images = _get_required_docker_cache_images,
-#@ get_file_upload_path = _get_file_upload_path)
+#@ get_file_upload_path = _get_file_upload_path,
+#@ get_image_run_args = _get_image_run_args)

--- a/.gflows/libs/job_unit_test.lib.yml
+++ b/.gflows/libs/job_unit_test.lib.yml
@@ -18,7 +18,7 @@
 #@ end
 ---
 #@ def _generate_run_job(unit_test_section, registry, sections, needs = ["version"]):
-#@   env = {"RESULTS_PATH":"TestResults","UNIT_TEST_IMAGE_TAG":tagging.image(registry, unit_test_section)}
+#@   env = {"RESULTS_PATH":"TestResults","UNIT_TEST_IMAGE_TAG":tagging.image(registry, unit_test_section),"IMAGE_RUN_ARGS":cfg.get_image_run_args(unit_test_section)}
 #@   job_name = job.name.docker_run(unit_test_section)
 #@   steps = unit_test_run_steps(unit_test_section, registry)
 #@   return  common.generate_job(unit_test_section,steps,env, sections, needs, job_name)
@@ -33,7 +33,7 @@
   run: |
     id=$(docker images "$UNIT_TEST_IMAGE_TAG" -q | head -n 1)
     echo "found image id: $id"
-    docker run --name unit_tests $id
+    docker run --name unit_tests $id $IMAGE_RUN_ARGS
 - #@ bpsteps.collect_results_step(config,"$UNIT_TEST_IMAGE_TAG")
 - #@ bpsteps.upload_artifacts_step(cfg.get_file_upload_path(config),"{} results".format(config.name))
 - #@ bpsteps.publish_test_result_as_check_step("${{ env.RESULTS_PATH }}/**/*.xml",config.name)

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -12,6 +12,10 @@ generic_job_example:
   # if dockerfile is missing, this field is considered as a dependency, all jobs will be searched for a one exporting this image name
   # image will be loaded into local docker to use for running or just use as a cache
   image_name: covergo/auth
+  #optional. Array of parameters to pass to docker image during run.
+  image_run_args: 
+  - "arg1"
+  - "arg 2"
   
   #optional, docker cache configuration. Can be a map or an array
   cache_from:
@@ -68,6 +72,9 @@ unit_test: #docker-build-and-job
   - name: Unit tests
     slug: auth-test-unit
     container_result_path: app/TestResults
+    image_run_args:
+      - "*.filter"
+      - "p aram2"
     dockerfile: Dockerfile
     image_name: covergo/auth-test-unit # image will be picked from this workflow-produced ones, if dokerfile is presented, image will be exported under this name
     cache_mode: min

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -285,7 +285,7 @@ jobs:
     env:
       RESULTS_PATH: TestResults
       UNIT_TEST_IMAGE_TAG: ghcr.io/covergo/auth-test-unit:${{ needs.version.outputs.app_version }}
-      IMAGE_RUN_ARGS: ""
+      IMAGE_RUN_ARGS: '"*.filter" "p aram2" '
     steps:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2


### PR DESCRIPTION
Add functionality to define docker run parameters.
Added new optional array field `image_run_args` to sections.
During the docker run, each item would be passed as an argument to `docker run`. 
Now works for unit tests image only.

Can be used in scenarios when we have a single unit test image but like to split different groups of tests on different jobs

