### PR TITLE
Allow to disable or enable cache load and push

### DIFF
--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -20,6 +20,14 @@
 #@ return getattr(_get_cache_subsection(section),"type", "registry")
 #@ end
 ---
+#@ def _get_cache_push(section):
+#@ return getattr(section,"cache_push",True)
+#@ end
+---
+#@ def _should_load_cache(section):
+#@ return getattr(section,"cache_load",True)
+#@ end
+---
 #@ def _get_file_upload_path(section):
 #@ return getattr(section,"upload_path","TestResults")
 #@ end
@@ -36,4 +44,6 @@
 #@ cfg = struct.make(get_cache_type = _get_cache_type,
 #@ get_required_docker_cache_images = _get_required_docker_cache_images,
 #@ get_file_upload_path = _get_file_upload_path,
-#@ get_image_run_args = _get_image_run_args)
+#@ get_image_run_args = _get_image_run_args,
+#@ should_push_cache = _get_cache_push,
+#@ should_load_cache = _should_load_cache)

--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -82,8 +82,12 @@ with:
   push: #@ push_image
   load: #@ load_image
   tags: #@ tags
+  #@ if cfg.should_load_cache(component):
   cache-from: #@ cache_params[cache_type].cache_from
+  #@ end
+  #@ if cfg.should_push_cache(component):
   cache-to: #@ cache_params[cache_type].cache_to
+  #@ end 
   #@ if hasattr(component,"docker_target"):
   target: #@ component.docker_target
   #@ end

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -147,6 +147,7 @@ nuget: #docker-build-and-job with special treatment of artifact
     container_result_path: app/nuget
     cache_from:
      - covergo/auth
+    cache_push: false
     publish_after:
      - acceptance-tests
   - name: Auth client nuget with default dependencies

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -96,7 +96,6 @@ jobs:
         cache-from: |-
           type=registry,ref=ghcr.io/covergo/auth-cache:${{ needs.version.outputs.issue_id_slug }}
           type=registry,ref=ghcr.io/covergo/auth-nuget-cache:${{ needs.version.outputs.issue_id_slug }}
-        cache-to: type=registry,ref=ghcr.io/covergo/auth-nuget-cache:${{ needs.version.outputs.issue_id_slug }},mode=max
         build-args: |
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}


### PR DESCRIPTION
Add functionality to control if image build job should push docker build cache or not. 

Add optional boolean setting `cache_push` to all docker-related section. Default value is true. If it is set to false, build cache would not be pushed to configured destination.

Useful in scenarios when the produced cache cannot be reused and we like to save on cache push time, which can be long. For example, when we build nuget packages with versioned dlls and using `repository` cache with `cache_mode=max` to consume main service-produced cache