### PR TITLE
Multiple projects for acceptance tests

### DIFF
--- a/.gflows/libs/job_integration_test.lib.yml
+++ b/.gflows/libs/job_integration_test.lib.yml
@@ -41,17 +41,19 @@
       behave_api_key: ${{ secrets.BEHAVE_PRO_TOKEN }}
       build_id: ${{ github.run_id }}
       build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      results_file: #@ "${{ env.RESULTS_PATH }}/"+getattr(integration_test_definition,"cucumber_result_filename")
+      results_file_filter: #@ "${{ env.RESULTS_PATH }}/"+getattr(integration_test_definition,"cucumber_result_filename")
     run: |
       latest_commit_sha=$(git rev-parse HEAD)
       echo "commit sha: $latest_commit_sha"
       echo "test result file: $results_file"
-      curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
-      -H "X-API-KEY: $behave_api_key" \
-      -H "X-COMMIT-ID: $latest_commit_sha" \
-      -H "X-BUILD-ID: $build_id" \
-      -H "X-BUILD-URL: $build_url" \
-      --data-binary @"$results_file" \
+      for results_file in $(ls "$results_file_filter"); do
+        curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
+        -H "X-API-KEY: $behave_api_key" \
+        -H "X-COMMIT-ID: $latest_commit_sha" \
+        -H "X-BUILD-ID: $build_id" \
+        -H "X-BUILD-URL: $build_url" \
+        --data-binary @"$results_file" \;
+      done;
   - name: #@ "Publish {} results as check".format(integration_test_definition.name)
     uses: deblockt/cucumber-report-annotations-action@v1.7
     if: always()

--- a/.gflows/libs/job_integration_test.lib.yml
+++ b/.gflows/libs/job_integration_test.lib.yml
@@ -45,15 +45,17 @@
     run: |
       latest_commit_sha=$(git rev-parse HEAD)
       echo "commit sha: $latest_commit_sha"
-      echo "test result file: $results_file"
-      for results_file in $(ls "$results_file_filter"); do
+      echo "test result file filter: $results_file_filter"
+      for results_file in $(ls "$results_file_filter") 
+      do
+        echo uploading "$results_file"
         curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
         -H "X-API-KEY: $behave_api_key" \
         -H "X-COMMIT-ID: $latest_commit_sha" \
         -H "X-BUILD-ID: $build_id" \
         -H "X-BUILD-URL: $build_url" \
-        --data-binary @"$results_file" \;
-      done;
+        --data-binary @"$results_file" 
+      done
   - name: #@ "Publish {} results as check".format(integration_test_definition.name)
     uses: deblockt/cucumber-report-annotations-action@v1.7
     if: always()

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -546,17 +546,19 @@ jobs:
         behave_api_key: ${{ secrets.BEHAVE_PRO_TOKEN }}
         build_id: ${{ github.run_id }}
         build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        results_file: ${{ env.RESULTS_PATH }}/cucumberResult.json
+        results_file_filter: ${{ env.RESULTS_PATH }}/cucumberResult.json
       run: |
         latest_commit_sha=$(git rev-parse HEAD)
         echo "commit sha: $latest_commit_sha"
         echo "test result file: $results_file"
-        curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
-        -H "X-API-KEY: $behave_api_key" \
-        -H "X-COMMIT-ID: $latest_commit_sha" \
-        -H "X-BUILD-ID: $build_id" \
-        -H "X-BUILD-URL: $build_url" \
-        --data-binary @"$results_file" \
+        for results_file in $(ls "$results_file_filter"); do
+          curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
+          -H "X-API-KEY: $behave_api_key" \
+          -H "X-COMMIT-ID: $latest_commit_sha" \
+          -H "X-BUILD-ID: $build_id" \
+          -H "X-BUILD-URL: $build_url" \
+          --data-binary @"$results_file" \;
+        done;
     - name: Publish Acceptance tests results as check
       uses: deblockt/cucumber-report-annotations-action@v1.7
       if: always()


### PR DESCRIPTION
Add support for multiple projects with acceptance tests 
`cucumber_result_filename` may contain a wildcard specifying several cucumber results files to upload to behave.pro