### PR TITLE
Added option to allow scan code job to extend needs

### DIFF
--- a/.gflows/libs/job_scan_code_net.lib.yml
+++ b/.gflows/libs/job_scan_code_net.lib.yml
@@ -1,5 +1,6 @@
 #@ load("common.lib.yml", "common")
 #@ load("configuration.lib.yml", "cfg")
+#@ load("job_dependency_resolution.lib.yml", "dep")
 ---
 #@ def generate_scan_code_net_job_steps(scan_code_net, sections):
 #@ test_result_artifacts = []
@@ -61,6 +62,7 @@
 #@ def generate_scan_code_net_job(scan_code_net, sections):
 #@ steps = generate_scan_code_net_job_steps(scan_code_net, sections)
 #@ needs = ["version"]
+#@ needs.extend(dep.get_job_needs(scan_code_net))
 #@ return common.generate_job(scan_code_net, steps, None, sections, needs, "Sonar scan")
 #@ end
 ---

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -238,6 +238,9 @@ scan_code_net:
   name: Sonar Code
   slug: scan_code_net
   #optional
+  cache_from:
+    - covergo/auth
+    - covergo/auth-test-unit
   sonar:
     coverage_solution_root_path: /sln
     verbose: 'true'

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -75,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - version
+    - docker-build-auth-service
+    - docker-build-auth-test-unit
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
By default scan_code_net job only needs "version" job , if  scan_code_net job is required to run after certain docker  images to be built, cache_from attr can be used. 

Example: 

```yml
scan_code_net:
  name: Sonar Code
  slug: scan_code_net
  #optional
  cache_from:
    - covergo/auth
    - covergo/auth-test-unit
```