### PR TITLE
Append candidate- to service tags in docker-composes file

### DIFF
--- a/.gflows/libs/build_publish_steps.lib.yml
+++ b/.gflows/libs/build_publish_steps.lib.yml
@@ -10,12 +10,18 @@
 #@ return "name=" + getattr(integration_test_component,"diagnostic_filter", "*")
 #@ end
 ---
-#@ def _compose_launch_steps(integration_test_definition, images):
+#@ def _compose_launch_steps(integration_test_definition, images, service_image):
     - name: Prepare compose file
       uses: ./.github/actions/set-compose-tags
       with:
         images: #@ images
         target-tag: ${{ needs.version.outputs.app_version }}
+        compose-file: #@ integration_test_definition.compose_file
+    - name: Prepare compose file
+      uses: ./.github/actions/set-compose-tags
+      with:
+        images: #@ service_image
+        target-tag: candidate-${{ needs.version.outputs.app_version }}
         compose-file: #@ integration_test_definition.compose_file
     - name: #@ "Run {}".format(integration_test_definition.name)
       uses: ./.github/actions/run-in-compose

--- a/.gflows/libs/job_integration_test.lib.yml
+++ b/.gflows/libs/job_integration_test.lib.yml
@@ -10,13 +10,13 @@
 #@ load("job_dependency_resolution.lib.yml", "dep")
 #@ load("configuration.lib.yml", "cfg")
 ---
-#@ def integration_test_run_job_steps(integration_test_definition, repository_built_images, cache_registry, main_registry=None):
+#@ def integration_test_run_job_steps(integration_test_definition, repository_built_images, cache_registry, service_image, main_registry=None):
   - #@ steps.checkout()
   - #@ steps.checkout_private_actions()
   #@ if(main_registry != None):
   - #@ steps.login_docker(main_registry)
   #@ end
-#@ for compose_step in bpsteps.compose_launch_steps(integration_test_definition,repository_built_images):
+#@ for compose_step in bpsteps.compose_launch_steps(integration_test_definition,repository_built_images,service_image):
   - #@ compose_step
 #@ end
   - #@ bpsteps.collect_results_step(integration_test_definition,tagging.image(cache_registry, integration_test_definition))
@@ -76,7 +76,7 @@
 #@ repository_built_images=dep.get_repository_built_images(sections)
 #@ steps_array = []
 #@ steps_array.append(steps.login_docker(sections.cache_registry))
-#@ steps_array.extend(integration_test_run_job_steps(integration_test_definition, repository_built_images, sections.cache_registry, getattr(sections,"main_registry",None)))
+#@ steps_array.extend(integration_test_run_job_steps(integration_test_definition, repository_built_images, sections.cache_registry, sections.service.image_name, getattr(sections,"main_registry",None)))
 #@ return common.generate_job(integration_test_definition, steps_array ,{"RESULTS_PATH": cfg.get_host_path_for_docker_extract(integration_test_definition)},sections, needs, job.name.docker_run(integration_test_definition))
 #@ end
 ---
@@ -101,7 +101,7 @@
 #@ repository_built_images=dep.get_repository_built_images(sections)
 #@ steps = []
 #@ steps.extend(docker.steps.build(integration_test_definition, sections.cache_registry))
-#@ steps.extend(integration_test_run_job_steps(integration_test_definition, repository_built_images, sections.cache_registry, getattr(sections,"main_registry",None)))
+#@ steps.extend(integration_test_run_job_steps(integration_test_definition, repository_built_images, sections.cache_registry, sections.service.image_name, getattr(sections,"main_registry",None)))
 #@ return common.generate_job(integration_test_definition, steps ,{"RESULTS_PATH": "TestResults"},sections, needs, job_name)
 #@ end
 ---

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -417,6 +417,12 @@ jobs:
         images: covergo/auth;covergo/auth-test-unit;covergo/cases-mariadb-test-integration;covergo/cases-test-acceptance;covergo/cases-api-test-integration;covergo/auth-mongo
         target-tag: ${{ needs.version.outputs.app_version }}
         compose-file: docker-compose.yml
+    - name: Prepare compose file
+      uses: ./.github/actions/set-compose-tags
+      with:
+        images: covergo/auth
+        target-tag: candidate-${{ needs.version.outputs.app_version }}
+        compose-file: docker-compose.yml
     - name: Run Integration tests
       uses: ./.github/actions/run-in-compose
       with:
@@ -530,6 +536,12 @@ jobs:
       with:
         images: covergo/auth;covergo/auth-test-unit;covergo/cases-mariadb-test-integration;covergo/cases-test-acceptance;covergo/cases-api-test-integration;covergo/auth-mongo
         target-tag: ${{ needs.version.outputs.app_version }}
+        compose-file: docker-compose.yml
+    - name: Prepare compose file
+      uses: ./.github/actions/set-compose-tags
+      with:
+        images: covergo/auth
+        target-tag: candidate-${{ needs.version.outputs.app_version }}
         compose-file: docker-compose.yml
     - name: Run Acceptance tests
       uses: ./.github/actions/run-in-compose
@@ -657,6 +669,12 @@ jobs:
       with:
         images: covergo/auth;covergo/auth-test-unit;covergo/cases-mariadb-test-integration;covergo/cases-test-acceptance;covergo/cases-api-test-integration;covergo/auth-mongo
         target-tag: ${{ needs.version.outputs.app_version }}
+        compose-file: docker-compose.mariadb.yml
+    - name: Prepare compose file
+      uses: ./.github/actions/set-compose-tags
+      with:
+        images: covergo/auth
+        target-tag: candidate-${{ needs.version.outputs.app_version }}
         compose-file: docker-compose.mariadb.yml
     - name: Run Integration API tests
       uses: ./.github/actions/run-in-compose


### PR DESCRIPTION
Services are tagged with  candidate-app_version , this should be reflected to the docker image tag in the  docker-compose file so that integration tests that use service images do not encounter to image not found errors
See BE-458