### PR TITLE
[BE-528] - Updates Workflow to Sign Docker Image After Publish

### DIFF
--- a/.gflows/config.yml
+++ b/.gflows/config.yml
@@ -9,5 +9,5 @@ templates:
       - libs
       - libs/jobs
     dependencies:
-      - https://raw.githubusercontent.com/CoverGo/ci-workflow-libraries/be-528-sign-docker-image/.gflows
+      - https://raw.githubusercontent.com/CoverGo/ci-workflow-libraries/v2.3/.gflows
 

--- a/.gflows/config.yml
+++ b/.gflows/config.yml
@@ -9,5 +9,5 @@ templates:
       - libs
       - libs/jobs
     dependencies:
-      - https://raw.githubusercontent.com/CoverGo/ci-workflow-libraries/v2.2/.gflows
+      - https://raw.githubusercontent.com/CoverGo/ci-workflow-libraries/be-528-sign-docker-image/.gflows
 

--- a/.gflows/libs/build_publish_steps.lib.yml
+++ b/.gflows/libs/build_publish_steps.lib.yml
@@ -78,10 +78,27 @@ with:
 #      ghcr.io/user/app:1.0.0
 #@ end
 ---
+#@ def _setup_cosign():
+name: Set up sigstore cosign
+uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+with:
+  cosign-release: 'v1.13.1'
+#@ end
+---
+#@ def _sign_container_with_cosign(image_name, image_digest):
+name: Sign published container image
+run: #@ "cosign sign --key env://COSIGN_PRIVATE_KEY {0}@{1}".format(image_name, image_digest)
+env:
+  COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+  COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+#@ end
+---
 #@ bpsteps = struct.make(
 #@ compose_launch_steps = _compose_launch_steps,
 #@ collect_results_step =  _collect_results_step,
 #@ upload_artifacts_step = _upload_artifacts_step,
 #@ publish_test_result_as_check_step = _publish_test_result_as_check_step,
 #@ copy_between_registries_step = _copy_between_registries_step,
-#@ get_compose_service_name_filter_to_diagnose = _get_compose_service_name_filter_to_diagnose)
+#@ get_compose_service_name_filter_to_diagnose = _get_compose_service_name_filter_to_diagnose,
+#@ setup_cosign = _setup_cosign,
+#@ sign_container_with_cosign = _sign_container_with_cosign)

--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -96,6 +96,10 @@
 #@ return getattr(section,"checkout_repo",False)
 #@ end
 ---
+#@ def _should_sign_docker_container(section):
+#@ return getattr(section, "sign_docker_container", False)
+#@ end
+---
 #@ cfg = struct.make(get_cache_type = _get_cache_type,
 #@ get_required_docker_cache_images = _get_required_docker_cache_images,
 #@ get_file_upload_path = _get_file_upload_path,
@@ -115,4 +119,5 @@
 #@ get_sonar_project_name = _get_sonar_project_name,
 #@ get_sonar_coverage_artifact_pooling_timeout_sec = _get_sonar_coverage_artifact_pooling_timeout_sec,
 #@ should_generate_docker_meta = _should_generate_docker_meta,
-#@ should_generate_sourcelink = _should_generate_sourcelink)
+#@ should_generate_sourcelink = _should_generate_sourcelink,
+#@ should_sign_docker_container = _should_sign_docker_container)

--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -96,8 +96,8 @@
 #@ return getattr(section,"checkout_repo",False)
 #@ end
 ---
-#@ def _should_sign_docker_container(section):
-#@ return getattr(section, "sign_docker_container", False)
+#@ def _should_output_docker_digest(section):
+#@ return getattr(section, "output_docker_digest", False)
 #@ end
 ---
 #@ cfg = struct.make(get_cache_type = _get_cache_type,
@@ -120,4 +120,4 @@
 #@ get_sonar_coverage_artifact_pooling_timeout_sec = _get_sonar_coverage_artifact_pooling_timeout_sec,
 #@ should_generate_docker_meta = _should_generate_docker_meta,
 #@ should_generate_sourcelink = _should_generate_sourcelink,
-#@ should_sign_docker_container = _should_sign_docker_container)
+#@ should_output_docker_digest = _should_output_docker_digest)

--- a/.gflows/libs/job_docker_build.lib.yml
+++ b/.gflows/libs/job_docker_build.lib.yml
@@ -23,11 +23,6 @@
 - #@ steps.build_and_push_docker(component, cache_registry, step_id=step_id_value, tags=tag_build, load_image=load_image, push_image=push_image,build_versioned_image=build_versioned_image)
 - name: Image digest
   run: #@ "echo ${{ steps."+step_id_value+".outputs.digest }}"
-  #@ if cfg.should_sign_docker_container(component):
-- #@ steps.setup_cosign()
-- #@ steps.save_private_key_for_cosign()
-- #@ steps.sign_container_with_cosign(tagging.image(cache_registry, component), "${{ steps." + step_id_value + ".outputs.digest }}")
-  #@ end
 #@ end
 ---
 #@ def _image_build_job(component, sections, needs=["version"], tag_build=None, job_name=None, push=True, environment_variables=None):

--- a/.gflows/libs/job_docker_build.lib.yml
+++ b/.gflows/libs/job_docker_build.lib.yml
@@ -21,14 +21,14 @@
 - #@ steps.generate_docker_meta()
   #@ end
 - #@ steps.build_and_push_docker(component, cache_registry, step_id=step_id_value, tags=tag_build, load_image=load_image, push_image=push_image,build_versioned_image=build_versioned_image)
-- name: Image digest
-  run: #@ "echo ${{ steps."+step_id_value+".outputs.digest }}"
+- #@ steps.echo_docker_digest(step_id_value, component)
 #@ end
 ---
 #@ def _image_build_job(component, sections, needs=["version"], tag_build=None, job_name=None, push=True, environment_variables=None):
-#@ steps = _image_build_job_steps(component, sections.cache_registry, tag_build, job_name,  push)
+#@ stepsYaml = _image_build_job_steps(component, sections.cache_registry, tag_build, job_name,  push)
 #@ job_name = common.get_value(job_name,job.name.docker_build(component))
-#@ return common.generate_job(component, steps, environment_variables, sections, needs, job_name)
+#@ outputs = steps.define_docker_outputs(component)
+#@ return common.generate_job(component, stepsYaml, environment_variables, sections, needs, job_name, outputs=outputs)
 #@ end
 ---
 #@ _docker_jobs = struct.make( build = _image_build_job)

--- a/.gflows/libs/job_docker_build.lib.yml
+++ b/.gflows/libs/job_docker_build.lib.yml
@@ -23,6 +23,11 @@
 - #@ steps.build_and_push_docker(component, cache_registry, step_id=step_id_value, tags=tag_build, load_image=load_image, push_image=push_image,build_versioned_image=build_versioned_image)
 - name: Image digest
   run: #@ "echo ${{ steps."+step_id_value+".outputs.digest }}"
+  #@ if cfg.should_sign_docker_container(component):
+- #@ steps.setup_cosign()
+- #@ steps.save_private_key_for_cosign()
+- #@ steps.sign_container_with_cosign(tagging.image(cache_registry, component), "${{ steps." + step_id_value + ".outputs.digest }}")
+  #@ end
 #@ end
 ---
 #@ def _image_build_job(component, sections, needs=["version"], tag_build=None, job_name=None, push=True, environment_variables=None):

--- a/.gflows/libs/job_docker_publish_alicloud.lib.yml
+++ b/.gflows/libs/job_docker_publish_alicloud.lib.yml
@@ -35,5 +35,7 @@
 - #@ steps.login_docker(sections.cache_registry)
 - #@ steps.login_docker(sections.main_registry)
 - #@ bpsteps.copy_between_registries_step(tagging.image(sections.cache_registry, sections.service),"${{ needs.version.outputs.docker_image_ali_cloud_tags }}",sections.main_registry.name)
+- #@ bpsteps.setup_cosign()
+- #@ bpsteps.sign_container_with_cosign("${{ needs.version.outputs.docker_image_ali_cloud_tags }}", "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
 #@ end
 ---

--- a/.gflows/libs/job_docker_publish_github.lib.yml
+++ b/.gflows/libs/job_docker_publish_github.lib.yml
@@ -32,5 +32,7 @@
 #@ def generate_docker_publish_github_steps(sections):
 - #@ steps.login_docker(sections.cache_registry)
 - #@ bpsteps.copy_between_registries_step(tagging.candidate_image(sections.cache_registry, sections.service),"${{ needs.version.outputs.docker_image_ghcr_tags }}",sections.cache_registry.name)
+- #@ bpsteps.setup_cosign()
+- #@ bpsteps.sign_container_with_cosign("${{ needs.version.outputs.docker_image_ghcr_tags }}", "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
 #@ end
 ---

--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -118,11 +118,34 @@ with:
   build-args: #@ "\n".join(build_args)
 #@ end
 ---
+#@ def _echo_docker_digest(step_id, component):
+name: Image digest
+#@ if cfg.should_output_docker_digest(component):
+env:
+  docker_digest: #@ "${{ steps." + step_id + ".outputs.digest }}"
+run: |
+  echo $docker_digest
+  echo "digest=$docker_digest" >> $GITHUB_OUTPUT
+#@ else:
+run: #@ "echo ${{ steps." + step_id + ".outputs.digest }}"
+#@ end
+#@ end
+---
+#@ def _define_docker_outputs(component):
+#@ if cfg.should_output_docker_digest(component):
+#@ return {"digest": "${{ steps." + job.id.docker_build(component) + ".outputs.digest }}"}
+#@ else:
+#@ return None
+#@ end
+#@ end
+---
 #@ steps = struct.make(login_docker = _login_docker,
 #@ checkout = _checkout,
 #@ setup_qemu = _setup_qemu,
 #@ setup_buildx = _setup_buildx,
 #@ checkout_private_actions = _checkout_private_actions,
 #@ build_and_push_docker = _build_and_push_docker,
-#@ generate_docker_meta = _generate_docker_meta)
+#@ generate_docker_meta = _generate_docker_meta,
+#@ define_docker_outputs = _define_docker_outputs,
+#@ echo_docker_digest = _echo_docker_digest)
 ---

--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -41,18 +41,37 @@ name: Set up Docker Buildx
 uses: docker/setup-buildx-action@v2
 #@ end
 ---
+#@ def _setup_cosign():
+name: Set up sigstore cosign
+uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+with:
+  cosign-release: 'v1.13.1'
+#@ end
+---
+#@ def _save_private_key_for_cosign():
+name: Write signing key to disk (only needed for `cosign sign --key`)
+run: echo "${{ secrets.SIGNING_SECRET }}" > cosign.key
+#@ end
+---
+#@ def _sign_container_with_cosign(image_name, image_digest):
+name: Sign published container image
+env:
+  COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+run: #@ "cosign sign --key cosign.key {0}@{1}".format(image_name, image_digest)
+#@ end
+---
 #@ def _checkout_private_actions():
 name: Checkout GitHub Action Repos
 uses: daspn/private-actions-checkout@v2
 with:
   actions_list: '[
-  "covergo/get-version@v1.6",
-  "covergo/get-issue-key@v1.3",
-  "covergo/docker-extract@v1.1",
-  "covergo/docker-diagnose@v1.8",
-  "covergo/set-compose-tags@v1.0.1",
-  "covergo/run-in-compose@v1"
-  ]'
+    "covergo/get-version@v1.6",
+    "covergo/get-issue-key@v1.3",
+    "covergo/docker-extract@v1.1",
+    "covergo/docker-diagnose@v1.8",
+    "covergo/set-compose-tags@v1.0.1",
+    "covergo/run-in-compose@v1"
+    ]'
   checkout_base_path: ./.github/actions
   app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
   app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -124,5 +143,8 @@ with:
 #@ setup_buildx = _setup_buildx,
 #@ checkout_private_actions = _checkout_private_actions,
 #@ build_and_push_docker = _build_and_push_docker,
-#@ generate_docker_meta = _generate_docker_meta)
+#@ generate_docker_meta = _generate_docker_meta,
+#@ setup_cosign = _setup_cosign,
+#@ save_private_key_for_cosign = _save_private_key_for_cosign,
+#@ sign_container_with_cosign = _sign_container_with_cosign)
 ---

--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -41,25 +41,6 @@ name: Set up Docker Buildx
 uses: docker/setup-buildx-action@v2
 #@ end
 ---
-#@ def _setup_cosign():
-name: Set up sigstore cosign
-uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
-with:
-  cosign-release: 'v1.13.1'
-#@ end
----
-#@ def _save_private_key_for_cosign():
-name: Write signing key to disk (only needed for `cosign sign --key`)
-run: echo "${{ secrets.SIGNING_SECRET }}" > cosign.key
-#@ end
----
-#@ def _sign_container_with_cosign(image_name, image_digest):
-name: Sign published container image
-env:
-  COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-run: #@ "cosign sign --key cosign.key {0}@{1}".format(image_name, image_digest)
-#@ end
----
 #@ def _checkout_private_actions():
 name: Checkout GitHub Action Repos
 uses: daspn/private-actions-checkout@v2
@@ -143,8 +124,5 @@ with:
 #@ setup_buildx = _setup_buildx,
 #@ checkout_private_actions = _checkout_private_actions,
 #@ build_and_push_docker = _build_and_push_docker,
-#@ generate_docker_meta = _generate_docker_meta,
-#@ setup_cosign = _setup_cosign,
-#@ save_private_key_for_cosign = _save_private_key_for_cosign,
-#@ sign_container_with_cosign = _sign_container_with_cosign)
+#@ generate_docker_meta = _generate_docker_meta)
 ---

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -66,7 +66,7 @@ service: #docker-build-and-job
   docker_target: build-service
   image_name: covergo/auth
   generate_docker_meta: true
-  sign_docker_container: true
+  output_docker_digest: true
 
 
 #Runs an existing image, can build if needed 

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -66,6 +66,7 @@ service: #docker-build-and-job
   docker_target: build-service
   image_name: covergo/auth
   generate_docker_meta: true
+  sign_docker_container: true
 
 
 #Runs an existing image, can build if needed 

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -265,6 +265,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - version
+    outputs:
+      digest: ${{ steps.docker-build-auth-service.outputs.digest }}
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -294,16 +296,11 @@ jobs:
         target: build-service
         build-args: COMMIT_SHA=${{ github.sha }}
     - name: Image digest
-      run: echo ${{ steps.docker-build-auth-service.outputs.digest }}
-    - name: Set up sigstore cosign
-      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
-      with:
-        cosign-release: v1.13.1
-    - name: Sign published container image
-      run: cosign sign --key env://COSIGN_PRIVATE_KEY ghcr.io/covergo/auth:${{ needs.version.outputs.app_version }}@${{ steps.docker-build-auth-service.outputs.digest }}
       env:
-        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-        COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+        docker_digest: ${{ steps.docker-build-auth-service.outputs.digest }}
+      run: |
+        echo $docker_digest
+        echo "digest=$docker_digest" >> $GITHUB_OUTPUT
   docker-build-auth-test-unit:
     name: Build Unit tests image
     timeout-minutes: 20
@@ -777,6 +774,15 @@ jobs:
       with:
         src: ghcr.io/covergo/auth:candidate-${{ needs.version.outputs.app_version }}
         dst: ${{ needs.version.outputs.docker_image_ghcr_tags }}
+    - name: Set up sigstore cosign
+      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+      with:
+        cosign-release: v1.13.1
+    - name: Sign published container image
+      run: cosign sign --key env://COSIGN_PRIVATE_KEY ${{ needs.version.outputs.docker_image_ghcr_tags }}@${{ needs.docker-build-auth-service.outputs.digest }}
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
   docker-publish-alicloud:
     name: Push service to AliCloud
     timeout-minutes: 20
@@ -810,6 +816,15 @@ jobs:
       with:
         src: ghcr.io/covergo/auth:${{ needs.version.outputs.app_version }}
         dst: ${{ needs.version.outputs.docker_image_ali_cloud_tags }}
+    - name: Set up sigstore cosign
+      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+      with:
+        cosign-release: v1.13.1
+    - name: Sign published container image
+      run: cosign sign --key env://COSIGN_PRIVATE_KEY ${{ needs.version.outputs.docker_image_ali_cloud_tags }}@${{ needs.docker-build-auth-service.outputs.digest }}
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
   integration-tests-legacy-big:
     name: Run legacy integration big tenants tests
     runs-on: self-hosted

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -295,6 +295,15 @@ jobs:
         build-args: COMMIT_SHA=${{ github.sha }}
     - name: Image digest
       run: echo ${{ steps.docker-build-auth-service.outputs.digest }}
+    - name: Set up sigstore cosign
+      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b
+      with:
+        cosign-release: v1.13.1
+    - name: Sign published container image
+      run: cosign sign --key env://COSIGN_PRIVATE_KEY ghcr.io/covergo/auth:${{ needs.version.outputs.app_version }}@${{ steps.docker-build-auth-service.outputs.digest }}
+      env:
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
   docker-build-auth-test-unit:
     name: Build Unit tests image
     timeout-minutes: 20


### PR DESCRIPTION
This PR updates the build-publish workflow to store docker image digest as output and sign the docker image with cosign after publishing to container registry.