### PR TITLE
[BE-528] - Fixes container image signing fails on master

### DIFF
--- a/.gflows/libs/job_docker_publish_alicloud.lib.yml
+++ b/.gflows/libs/job_docker_publish_alicloud.lib.yml
@@ -36,6 +36,6 @@
 - #@ steps.login_docker(sections.main_registry)
 - #@ bpsteps.copy_between_registries_step(tagging.image(sections.cache_registry, sections.service),"${{ needs.version.outputs.docker_image_ali_cloud_tags }}",sections.main_registry.name)
 - #@ bpsteps.setup_cosign()
-- #@ bpsteps.sign_container_with_cosign("${{ needs.version.outputs.docker_image_ali_cloud_tags }}", "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
+- #@ bpsteps.sign_container_with_cosign(tagging.with_registry(sections.main_registry.url,sections.service.image_name,"${{ needs.version.outputs.app_version }}"), "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
 #@ end
 ---

--- a/.gflows/libs/job_docker_publish_github.lib.yml
+++ b/.gflows/libs/job_docker_publish_github.lib.yml
@@ -33,6 +33,6 @@
 - #@ steps.login_docker(sections.cache_registry)
 - #@ bpsteps.copy_between_registries_step(tagging.candidate_image(sections.cache_registry, sections.service),"${{ needs.version.outputs.docker_image_ghcr_tags }}",sections.cache_registry.name)
 - #@ bpsteps.setup_cosign()
-- #@ bpsteps.sign_container_with_cosign("${{ needs.version.outputs.docker_image_ghcr_tags }}", "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
+- #@ bpsteps.sign_container_with_cosign(tagging.with_registry(sections.cache_registry.url,sections.service.image_name,"${{ needs.version.outputs.app_version }}"), "${{ needs." + job.id.docker_build(data.values.service) + ".outputs.digest }}")
 #@ end
 ---

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -779,7 +779,7 @@ jobs:
       with:
         cosign-release: v1.13.1
     - name: Sign published container image
-      run: cosign sign --key env://COSIGN_PRIVATE_KEY ${{ needs.version.outputs.docker_image_ghcr_tags }}@${{ needs.docker-build-auth-service.outputs.digest }}
+      run: cosign sign --key env://COSIGN_PRIVATE_KEY ghcr.io/covergo/auth:${{ needs.version.outputs.app_version }}@${{ needs.docker-build-auth-service.outputs.digest }}
       env:
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
@@ -821,7 +821,7 @@ jobs:
       with:
         cosign-release: v1.13.1
     - name: Sign published container image
-      run: cosign sign --key env://COSIGN_PRIVATE_KEY ${{ needs.version.outputs.docker_image_ali_cloud_tags }}@${{ needs.docker-build-auth-service.outputs.digest }}
+      run: cosign sign --key env://COSIGN_PRIVATE_KEY registry-intl.cn-hongkong.aliyuncs.com/covergo/auth:${{ needs.version.outputs.app_version }}@${{ needs.docker-build-auth-service.outputs.digest }}
       env:
         COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
         COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}


### PR DESCRIPTION
`docker_image_ghcr_tags` and `docker_image_ali_cloud_tags` contain multiple comma separated docker image url when merged to master or tagged. This causes image signing command to fail. This PR aims to fix it by using the [versioned docker image url](https://github.com/CoverGo/build-publish-net-workflow/blob/ce3f341f5af6bb5c13fb1aadd89d7ef8085227a4/github-sample/workflows/build-publish.yml#L54) for both registries.