### PR TITLE
Add code coverage summary support for unit and integration tests.

### DIFF
--- a/.gflows/libs/build_publish_steps.lib.yml
+++ b/.gflows/libs/build_publish_steps.lib.yml
@@ -93,6 +93,38 @@ env:
   COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 #@ end
 ---
+#@ def _code_coverage_summary(file_name):
+name: Code Coverage Summary Report
+uses: irongut/CodeCoverageSummary@v1.3.0
+with:
+  filename: #@ file_name
+  badge: true
+  format: markdown
+  indicators: true
+  output: both
+  thresholds: '60 80'
+#@ end
+---
+#@ def _find_pr_number():
+name: Find PR number
+uses: jwalton/gh-find-current-pr@v1
+id: findPr
+#@ end
+---
+#@ def _pull_request_comment(id):
+uses: marocchino/sticky-pull-request-comment@v2
+with:
+  number: ${{ steps.findPr.outputs.pr }}
+  header: #@ id
+  recreate: true
+  path: code-coverage-results.md
+#@ end
+---
+#@ def _add_coverage_step_summary():
+name: Add Coverage Step Summary
+run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+#@ end
+---
 #@ bpsteps = struct.make(
 #@ compose_launch_steps = _compose_launch_steps,
 #@ collect_results_step =  _collect_results_step,
@@ -101,4 +133,8 @@ env:
 #@ copy_between_registries_step = _copy_between_registries_step,
 #@ get_compose_service_name_filter_to_diagnose = _get_compose_service_name_filter_to_diagnose,
 #@ setup_cosign = _setup_cosign,
-#@ sign_container_with_cosign = _sign_container_with_cosign)
+#@ sign_container_with_cosign = _sign_container_with_cosign,
+#@ code_coverage_summary = _code_coverage_summary,
+#@ find_pr_number = _find_pr_number,
+#@ pull_request_comment = _pull_request_comment,
+#@ add_coverage_step_summary = _add_coverage_step_summary)

--- a/.gflows/libs/job_integration_test.lib.yml
+++ b/.gflows/libs/job_integration_test.lib.yml
@@ -65,6 +65,12 @@
       access-token: ${{ secrets.GITHUB_TOKEN }}
       path: #@ cfg.get_host_path_for_docker_extract(integration_test_definition)+"/"+getattr(integration_test_definition,"cucumber_result_filename")
     #@ end
+  #@ if hasattr(integration_test_definition,"coverage_file_name") :
+  - #@ bpsteps.code_coverage_summary(getattr(integration_test_definition,"coverage_file_name"))
+  - #@ bpsteps.add_coverage_step_summary()
+  - #@ bpsteps.find_pr_number()
+  - #@ bpsteps.pull_request_comment("IntegrationTestsCoverage")
+    #@ end
   #@ end
 ---
 #@ def _integration_test_run_job(integration_test_definition, sections, needs = ["version"]):

--- a/.gflows/libs/job_unit_test.lib.yml
+++ b/.gflows/libs/job_unit_test.lib.yml
@@ -39,6 +39,12 @@
 - #@ bpsteps.collect_results_step(config,"$UNIT_TEST_IMAGE_TAG")
 - #@ bpsteps.upload_artifacts_step(cfg.get_file_upload_path(config),"{} results".format(config.name))
 - #@ bpsteps.publish_test_result_as_check_step(cfg.get_test_check_source_files(config),config.name)
+#@ if hasattr(config,"coverage_file_name") :
+- #@ bpsteps.code_coverage_summary(getattr(config,"coverage_file_name"))
+- #@ bpsteps.add_coverage_step_summary()
+- #@ bpsteps.find_pr_number()
+- #@ bpsteps.pull_request_comment("UnitTestsCoverage")
+  #@ end
 #@ end
 ---
 #@ def _generate_build_run_job(section, registry, sections, job_name=None):

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -87,6 +87,7 @@ unit_test: #docker-build-and-job
       bce
       !fge 
       !hep/**/.tmp
+    coverage_file_name: ./TestResults/**/*.cobertura.xml # If coverage file or files in cobertura format are specified it adds steps to publish code coverage summary as check and PR comment.
 #Runs existing images in compose, can build if needed
 integration_test: #array of docker-build-and-job 
   - name: Integration tests
@@ -119,6 +120,7 @@ integration_test: #array of docker-build-and-job
       - covergo/auth
       - covergo/auth-test-unit
       - covergo/cases-api-test-integration
+    coverage_file_name: ./TestResults/*.cobertura.xml # If coverage file or files in cobertura format are specified it adds steps to publish code coverage summary as check and PR comment.
       
   - name: Integration API tests
     slug: api-test-integration


### PR DESCRIPTION
When code_coverage_file attribute is set to a cobertura coverage file steps to display coverage summary will be added.