### PR TITLE
feat: Custom build args support for docker build

### DIFF
--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -109,6 +109,9 @@ with:
   target: #@ component.docker_target
   #@ end
   #@ build_args = []
+  #@ if hasattr(component,"build_args"):
+  #@  build_args += component.build_args
+  #@ end
   #@ build_args.append("COMMIT_SHA=${{ github.sha }}")
   #@ if build_versioned_image:
   #@ build_args.append("APP_VERSION=${{ needs.version.outputs.app_version }}")

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -70,6 +70,8 @@ services:
     image_name: covergo/auth
     generate_docker_meta: true
     output_docker_digest: true
+    build_args: 
+      - NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
   - name: Auth Predeployment
     slug: auth-predeployment
     dockerfile: Dockerfile

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -264,6 +264,7 @@ jobs:
         cache-to: type=registry,ref=ghcr.io/covergo/auth-cache:${{ needs.version.outputs.issue_id_slug }},mode=max
         target: build-service
         build-args: |-
+          NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           COMMIT_SHA=${{ github.sha }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}


### PR DESCRIPTION
Currently, we are setting docker build args within the gflow template. We want to expand this and accept custom docker build-args  to be passed to the components. This will allow services to pass custom build-args to the workflow. It is also optional.