### PR TITLE
Add `update leaderboard` job

### DIFF
--- a/.gflows/gflowspkg.json
+++ b/.gflows/gflowspkg.json
@@ -21,6 +21,7 @@
     "libs/job_build_nuget.lib.yml",
     "libs/job_unit_test.lib.yml",
     "libs/job_version.lib.yml",
-    "libs/job_deploy_tenants.lib.yml"
+    "libs/job_deploy_tenants.lib.yml",
+    "libs/job_update_leaderboard.lib.yml"
   ]
 }

--- a/.gflows/libs/job_update_leaderboard.lib.yml
+++ b/.gflows/libs/job_update_leaderboard.lib.yml
@@ -1,0 +1,20 @@
+#@ load("naming.lib.yml", "job")
+#@ load("steps.lib.yml", "steps")
+#@ load("common.lib.yml", "common")
+
+---
+#@ def generate_update_leaderboard_job_steps(update_leaderboard_section):
+- uses: victorx64/pr-label@v0
+  with:
+    #@ if hasattr(update_leaderboard_section,"git-pathspec") :
+    git-pathspec: #@ update_leaderboard_section["git-pathspec"]
+    #@ end
+#@ end
+---
+#@ def update_leaderboard_job(update_leaderboard_section):
+#@ steps = generate_update_leaderboard_job_steps(update_leaderboard_section)
+#@ branchCondition = common.build_git_branches_condition(update_leaderboard_section)
+#@ return common.generate_job(update_leaderboard_section, steps, None, None, None, None, branchCondition)
+#@ end
+---
+

--- a/.gflows/workflows/build-publish/build-publish.template.yml
+++ b/.gflows/workflows/build-publish/build-publish.template.yml
@@ -15,6 +15,7 @@
 #@  load("job_integration_tests_legacy.lib.yml", "generate_integration_test_legacy_small")
 #@  load("job_integration_tests_legacy.lib.yml", "generate_integration_test_legacy_big")
 #@  load("job_deploy_tenants.lib.yml", "tenant_deploy_steps")
+#@  load("job_update_leaderboard.lib.yml", "update_leaderboard_job")
 #@  load("naming.lib.yml", "job")
 #@  load("steps.lib.yml", "steps")
 #@  load("common.lib.yml", "common")
@@ -116,7 +117,11 @@
     #@   jobs[common.job_id(tenant, "deploy-tenant-")] = tenant_deploy_steps(data.values.deploy_tenants, tenant, deploy_tenants_registry_section, service_sections)
     #@ end
   #@ end
-  
+
+  #@ if hasattr(data.values,"update_leaderboard"):
+  #@  jobs["update-leaderboard"] = update_leaderboard_job(data.values.update_leaderboard)
+  #@ end
+
   #@ return jobs
 #@ end
 


### PR DESCRIPTION
BE-740

This PR adds a job that creates a leaderboard of contributors. A poll was started in the `#backend` channel (https://covergo.slack.com/archives/G013PMH64T0/p1676279723004669) and as of now the majority (4 vs 2) voted to add the gamification.

The job uploads `leaderboard.md` file to GitHub Actions Artifacts.