### PR TITLE
BE-774 Implement SonarCloud analysis for non-dotnet repos

### DIFF
--- a/.gflows/gflowspkg.json
+++ b/.gflows/gflowspkg.json
@@ -18,6 +18,7 @@
     "libs/job_integration_tests_legacy.lib.yml",
     "libs/job_publish_nuget.lib.yml",
     "libs/job_scan_code_net.lib.yml",
+    "libs/job_scan_code.lib.yml",
     "libs/job_build_nuget.lib.yml",
     "libs/job_unit_test.lib.yml",
     "libs/job_version.lib.yml",

--- a/.gflows/libs/job_scan_code.lib.yml
+++ b/.gflows/libs/job_scan_code.lib.yml
@@ -1,0 +1,23 @@
+---
+#@ def generate_scan_code_job(section):
+  name: #@ section["name"]
+  runs-on: ubuntu-latest
+  timeout-minutes: 10
+  steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: downcase GITHUB_REPOSITORY_OWNER
+        run: |
+          echo "GITHUB_REPOSITORY_OWNER_DOWNCASE=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.organization=${{ env.GITHUB_REPOSITORY_OWNER_DOWNCASE }}
+            -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#@ end
+---

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -1,3 +1,5 @@
+# Example build-publish settings file
+
 #@data/values
 ---
 
@@ -266,6 +268,9 @@ scan_code_net:
     organisation: covergo
     project_name: Auth Service
     coverage_artifact_pooling_timeout_sec: '1200'
+
+scan_code:
+  name: Sonar scan
 
 deploy_tenants:
   runner: self-hosted

--- a/.gflows/workflows/build-publish/build-publish.template.yml
+++ b/.gflows/workflows/build-publish/build-publish.template.yml
@@ -11,6 +11,7 @@
 #@  load("job_docker_publish_alicloud.lib.yml", "docker_publish_alicloud_job")
 #@  load("job_publish_nuget.lib.yml", "generate_nuget_publish_job")
 #@  load("job_scan_code_net.lib.yml", "generate_scan_code_net_job")
+#@  load("job_scan_code.lib.yml", "generate_scan_code_job")
 #@  load("job_build_nuget.lib.yml", "generate_nuget_build_job")
 #@  load("job_integration_tests_legacy.lib.yml", "generate_integration_test_legacy_small")
 #@  load("job_integration_tests_legacy.lib.yml", "generate_integration_test_legacy_big")
@@ -29,7 +30,11 @@
   #@ jobs = {"version": generate_version_job(data.values)}   
   
   #@ if hasattr(data.values,"scan_code_net"):
-  #@  jobs["scan-code"] = generate_scan_code_net_job(data.values.scan_code_net, data.values)
+  #@  jobs["scan-code-net"] = generate_scan_code_net_job(data.values.scan_code_net, data.values)
+  #@ end
+
+  #@ if hasattr(data.values,"scan_code"):
+  #@  jobs["scan-code"] = generate_scan_code_job(data.values.scan_code)
   #@ end
 
   #@ if hasattr(data.values,"nuget"):

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 Build-publish workflow template generates a GithubCI workflow which converts a repository source code into published Docker images.
-The template is designed for .Net backend microservice repositories.
+The template is mostly intended for .Net backend microservice repositories, however it can also be used for non-.Net services to implement some common logic like image versioning and code scanning.
 Template produces hi-quality, production-ready workflow taking care of common aspect like unit, integration and acceptance testing,
 nuget publishing, build cache, versioning, docker images tagging, test result collection and so on.
 Template is designed for mid-size organisations to generate a workflow with gflows cli local tools using a configuration file.

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -54,7 +54,7 @@ jobs:
         if [[ ${{ steps.version.outputs.app_version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo ::set-output name=is_production::true
         fi
-  scan-code:
+  scan-code-net:
     name: Sonar scan
     timeout-minutes: 20
     runs-on: ubuntu-latest
@@ -81,6 +81,25 @@ jobs:
         coverage-artifact-pooling-timeout-sec: "1200"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  scan-code:
+    name: Sonar scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: downcase GITHUB_REPOSITORY_OWNER
+      run: |
+        echo "GITHUB_REPOSITORY_OWNER_DOWNCASE=${GITHUB_REPOSITORY_OWNER,,}" >>${GITHUB_ENV}
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@master
+      with:
+        args: |
+          -Dsonar.organization=${{ env.GITHUB_REPOSITORY_OWNER_DOWNCASE }} -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   nuget-build-auth-nuget:
     name: Build Auth client nuget
     timeout-minutes: 20
@@ -113,7 +132,7 @@ jobs:
         build-args: |-
           COMMIT_SHA=${{ github.sha }}
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          BUILD_DATETIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}
           INFORMATIONAL_VERSION=${{ needs.version.outputs.information_version }}
@@ -125,7 +144,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -187,7 +206,7 @@ jobs:
         build-args: |-
           COMMIT_SHA=${{ github.sha }}
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          BUILD_DATETIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}
           INFORMATIONAL_VERSION=${{ needs.version.outputs.information_version }}
@@ -199,7 +218,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -274,7 +293,7 @@ jobs:
           NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           COMMIT_SHA=${{ github.sha }}
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          BUILD_DATETIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}
           INFORMATIONAL_VERSION=${{ needs.version.outputs.information_version }}
@@ -325,7 +344,7 @@ jobs:
         build-args: |-
           COMMIT_SHA=${{ github.sha }}
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          BUILD_DATETIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}
           INFORMATIONAL_VERSION=${{ needs.version.outputs.information_version }}
@@ -394,7 +413,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -470,7 +489,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -594,7 +613,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -731,7 +750,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}
@@ -1063,7 +1082,7 @@ jobs:
     - name: Checkout GitHub Action Repos
       uses: daspn/private-actions-checkout@v2
       with:
-        actions_list: '[ "covergo/get-version@v1.7", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
+        actions_list: '[ "covergo/get-version@v1.8", "covergo/get-issue-key@v1.3", "covergo/docker-extract@v1.1", "covergo/docker-diagnose@v1.8", "covergo/set-compose-tags@v1.0.1", "covergo/run-in-compose@v1.1" ]'
         checkout_base_path: ./.github/actions
         app_id: ${{ secrets.PRIVATE_ACTION_APP_ID }}
         app_private_key: ${{ secrets.PRIVATE_ACTION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description
This PR enables support for SonarCloud analysis in non-dotnet repos. It's supposed to be used to enable SonarCloud quality gates in BE-owned JavaScript repos like [data-migrations](https://github.com/CoverGo/saas-data-migrations) and Scripts-js.

Can be used like this:
![image](https://user-images.githubusercontent.com/44471919/235189422-afb9baa2-f876-4e8d-914a-a3d7901944ac.png)
After applying gflows transformation it results in the following GitHub action job:
![image](https://user-images.githubusercontent.com/44471919/235189657-114c8e03-bf0c-4c47-9927-f793eb78a5f7.png)
