### PR TITLE
fix: failed when override the sonar project key

### DIFF
--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -84,6 +84,10 @@
 #@ return getattr(section.sonar, "project_name")
 #@ end
 ---
+#@ def _get_sonar_project(section):
+#@ return getattr(section.sonar, "project")
+#@ end
+---
 #@ def _get_sonar_coverage_artifact_pooling_timeout_sec(section):
 #@ return getattr(section.sonar, "coverage_artifact_pooling_timeout_sec")
 #@ end


### PR DESCRIPTION
This function `get_sonar_project` is used on the file `job_scan_code_net.lib.yml` but the implementation of the function is missing so the gflows failed to generate when we try to override the project key.