### PR TITLE
Fix/fail when overriding the project key

### DIFF
--- a/.gflows/libs/configuration.lib.yml
+++ b/.gflows/libs/configuration.lib.yml
@@ -121,6 +121,7 @@
 #@ get_sonar_vstest_reports_paths = _get_sonar_vstest_reports_paths,
 #@ get_sonar_organization = _get_sonar_organization,
 #@ get_sonar_project_name = _get_sonar_project_name,
+#@ get_sonar_project = _get_sonar_project,
 #@ get_sonar_coverage_artifact_pooling_timeout_sec = _get_sonar_coverage_artifact_pooling_timeout_sec,
 #@ should_generate_docker_meta = _should_generate_docker_meta,
 #@ should_generate_sourcelink = _should_generate_sourcelink,


### PR DESCRIPTION
This function get_sonar_project is used on the file job_scan_code_net.lib.yml but the implementation of the function is missing so the gflows failed to generate when we try to override the project key.