### PR TITLE
fix: update cucumber report

### DIFF
--- a/.gflows/libs/job_integration_test.lib.yml
+++ b/.gflows/libs/job_integration_test.lib.yml
@@ -47,7 +47,7 @@
       latest_commit_sha=$(git rev-parse HEAD)
       echo "commit sha: $latest_commit_sha"
       echo "test result file filter: $results_file_filter"
-      for results_file in $(ls "$results_file_filter") 
+      for results_file in $(ls "$results_file_filter")
       do
         echo uploading "$results_file"
         curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
@@ -55,10 +55,10 @@
         -H "X-COMMIT-ID: $latest_commit_sha" \
         -H "X-BUILD-ID: $build_id" \
         -H "X-BUILD-URL: $build_url" \
-        --data-binary @"$results_file" 
+        --data-binary @"$results_file"
       done
   - name: #@ "Publish {} results as check".format(integration_test_definition.name)
-    uses: deblockt/cucumber-report-annotations-action@v1.7
+    uses: deblockt/cucumber-report-annotations-action@v1.11
     if: always()
     with:
       name: #@ "{} check".format(integration_test_definition.name)
@@ -73,7 +73,7 @@
 #@    needs.append(dep.find_job_for_image(image))
 #@  end
 #@ end
-#@  
+#@
 #@ repository_built_images=dep.get_repository_built_images(sections)
 #@ repository_built_images_to_publish=dep.get_repository_built_images_to_publish(sections)
 #@ steps_array = []
@@ -90,16 +90,16 @@
 ---
 #@ def _integration_test_build_and_run_job(integration_test_definition, sections):
 #@ job_name = job.name.build_and_run(integration_test_definition)
-  
+
 #@ needs = ["version"]
 #@ needs.extend(dep.get_job_needs(integration_test_definition))
-  
+
 #@ if hasattr(integration_test_definition, "compose_images"):
 #@  for image in integration_test_definition.compose_images:
 #@    needs.append(dep.find_job_for_image(image))
 #@  end
 #@ end
-#@  
+#@
 #@ repository_built_images=dep.get_repository_built_images(sections)
 #@ repository_built_images_to_publish=dep.get_repository_built_images_to_publish(sections)
 #@ steps = []
@@ -118,5 +118,4 @@
 
 
 
-      
-      
+

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -685,9 +685,22 @@ jobs:
         build_id: ${{ github.run_id }}
         build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         results_file_filter: ./TestResults/cucumberResult.json
-      run: "latest_commit_sha=$(git rev-parse HEAD)\necho \"commit sha: $latest_commit_sha\"\necho \"test result file filter: $results_file_filter\"\nfor results_file in $(ls \"$results_file_filter\") \ndo\n  echo uploading \"$results_file\"\n  curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \\\n  -H \"X-API-KEY: $behave_api_key\" \\\n  -H \"X-COMMIT-ID: $latest_commit_sha\" \\\n  -H \"X-BUILD-ID: $build_id\" \\\n  -H \"X-BUILD-URL: $build_url\" \\\n  --data-binary @\"$results_file\" \ndone\n"
+      run: |
+        latest_commit_sha=$(git rev-parse HEAD)
+        echo "commit sha: $latest_commit_sha"
+        echo "test result file filter: $results_file_filter"
+        for results_file in $(ls "$results_file_filter")
+        do
+          echo uploading "$results_file"
+          curl -L -X PUT --fail https://test-reports.behave.pro/REST/1.0/bdd/report \
+          -H "X-API-KEY: $behave_api_key" \
+          -H "X-COMMIT-ID: $latest_commit_sha" \
+          -H "X-BUILD-ID: $build_id" \
+          -H "X-BUILD-URL: $build_url" \
+          --data-binary @"$results_file"
+        done
     - name: Publish Acceptance tests results as check
-      uses: deblockt/cucumber-report-annotations-action@v1.7
+      uses: deblockt/cucumber-report-annotations-action@v1.11
       if: always()
       with:
         name: Acceptance tests check


### PR DESCRIPTION
Trying to fix such errors:
```
start to read cucumber logs using path ./TestResults/FeatureData.json
found cucumber report /home/runner/work/Policies/Policies/TestResults/FeatureData.json
/home/runner/work/_actions/deblockt/cucumber-report-annotations-action/v1.7/reportReader.js:5
        .map(fileReport => globalFileInformation(fileReport))
         ^

TypeError: report.map is not a function
    at Object.module.exports.globalInformation (/home/runner/work/_actions/deblockt/cucumber-report-annotations-action/v1.7/reportReader.js:5:10)
    at /home/runner/work/_actions/deblockt/cucumber-report-annotations-action/v1.7/index.js:75:48
```

BE-806