### PR TITLE
BE-770 fix: use buildx 0.11.2 to fix failing builds

### DIFF
--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -39,6 +39,8 @@ uses: docker/setup-qemu-action@v1
 #@ def _setup_buildx():
 name: Set up Docker Buildx
 uses: docker/setup-buildx-action@v2
+with:
+  version: v0.11.2
 #@ end
 ---
 #@ def _checkout_private_actions():

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -117,6 +117,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -193,6 +195,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -275,6 +279,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -327,6 +333,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -382,6 +390,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -475,6 +485,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -584,6 +596,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -737,6 +751,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -1182,6 +1198,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.11.2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
We can drop this hard code once `ubuntu-latest` image will feature buildx 0.11.2+