### PR TITLE
added a new lib to the bundle

### DIFF
--- a/.gflows/gflowspkg.json
+++ b/.gflows/gflowspkg.json
@@ -20,6 +20,7 @@
     "libs/job_publish_nuget.lib.yml",
     "libs/job_scan_code_net.lib.yml",
     "libs/job_scan_code.lib.yml",
+    "libs/job_scan_image.lib.yml",
     "libs/job_build_nuget.lib.yml",
     "libs/job_unit_test.lib.yml",
     "libs/job_version.lib.yml",


### PR DESCRIPTION
an issue appeared after tagging with release version and trying to use it in Gateway service:
```
root@DESKTOP-VEKT32C:/mnt/c/Projects/Gateway# gflows update help
      error .github/workflows/build-publish.yml (from build-publish-net/workflows/build-publish)
  ► - cannot load job_scan_image.lib.yml: Expected to find file 'job_scan_image.lib.yml' (hint: only files included via -f flag are available)
  identical .github/workflows/workflows-check.yml (from workflow-check/workflows/workflows-check)
  identical .github/workflows/helm-chart.yml (from helm-chart/workflows/helm-chart)
```
  looks like it's mandatory to add the lib to the package list bundle