### PR TITLE
CH-11556 Upgrade version of upload-artifact action

### DIFF
--- a/.gflows/libs/build_publish_steps.lib.yml
+++ b/.gflows/libs/build_publish_steps.lib.yml
@@ -49,7 +49,7 @@ with:
 #@ end
 name: #@ step_name
 if: #@ ifExpression
-uses: actions/upload-artifact@v2
+uses: actions/upload-artifact@v4
 with:
   name: #@ artifact_name
   path: #@ path

--- a/.gflows/libs/integration-tests-legacy-steps.lib.yml
+++ b/.gflows/libs/integration-tests-legacy-steps.lib.yml
@@ -17,9 +17,9 @@
 - name: Prepare environment for integration tests
   uses: ./launch_environment
   with:
-    mongo-user: #@ environment.mongo_user 
-    mongo-password: #@ environment.mongo_password 
-    mongo-url: #@ environment.mongo_url 
+    mongo-user: #@ environment.mongo_user
+    mongo-password: #@ environment.mongo_password
+    mongo-url: #@ environment.mongo_url
     service-under-test: #@ environment.service_under_test.name
     image-under-test: #@ tagging.candidate_image(registry, environment.service_under_test.image)
 
@@ -28,7 +28,7 @@
   run: yarn install
 #@ for test_case in test_suites.tests:
 - name: #@ "Run {} tests".format(test_case)
-  run: #@ "yarn {}".format(test_case) 
+  run: #@ "yarn {}".format(test_case)
 #@ end
 - name: Gather test environment logs
   if: ${{ always() }}
@@ -43,7 +43,7 @@
   run: docker compose down --remove-orphans
 - name: Upload test environment logs as artifact
   if: ${{ always() }}
-  uses: actions/upload-artifact@v2
+  uses: actions/upload-artifact@v4
   with:
     name: #@ "{} diagnostics".format(test_suites.name)
     path: diagnostics/*

--- a/.gflows/libs/job_build_nuget.lib.yml
+++ b/.gflows/libs/job_build_nuget.lib.yml
@@ -24,7 +24,7 @@
     container-path: #@ nuget.container_result_path
     host-path: ./nuget
 - name: Upload nuget packages as artifacts
-  uses: actions/upload-artifact@v2
+  uses: actions/upload-artifact@v4
   with:
     name: Nuget packages
     path: ./nuget

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -164,7 +164,7 @@ jobs:
         container-path: app/nuget
         host-path: ./nuget
     - name: Upload nuget packages as artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Nuget packages
         path: ./nuget
@@ -242,7 +242,7 @@ jobs:
         container-path: app/nuget
         host-path: ./nuget
     - name: Upload nuget packages as artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Nuget packages
         path: ./nuget
@@ -458,7 +458,7 @@ jobs:
         host-path: ./TestResults
     - name: Upload Unit tests results as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Unit tests results
         path: |
@@ -570,13 +570,13 @@ jobs:
         project-name: integration-test
     - name: Upload Integration tests environment diagnostics as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Integration tests environment diagnostics
         path: investigate/*
     - name: Upload Integration tests results as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Integration tests results
         path: TestResults
@@ -699,13 +699,13 @@ jobs:
         project-name: integration-test
     - name: Upload Acceptance tests environment diagnostics as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Acceptance tests environment diagnostics
         path: investigate/*
     - name: Upload Acceptance tests results as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Acceptance tests results
         path: TestResults
@@ -854,13 +854,13 @@ jobs:
         project-name: integration-test
     - name: Upload Integration API tests environment diagnostics as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Integration API tests environment diagnostics
         path: investigate/*
     - name: Upload Integration API tests results as artifact
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Integration API tests results
         path: abc
@@ -1195,7 +1195,7 @@ jobs:
       run: docker compose down --remove-orphans
     - name: Upload test environment logs as artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Big tenants legacy integration tests diagnostics
         path: diagnostics/*


### PR DESCRIPTION
# Description

Upgrade upload-artifact action to version 4

Error message
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: [Deprecation notice: v1 and v2 of the artifact actions · GitHub Changelog](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
```