### PR TITLE
added an option to specify the docker_config_path for custom runners

### DIFF
--- a/.gflows/libs/build_publish_steps.lib.yml
+++ b/.gflows/libs/build_publish_steps.lib.yml
@@ -73,7 +73,7 @@ with:
   check_run_annotations: none  # Disable additional annotations to reduce API calls
 #@ end
 ---
-#@ def _copy_between_registries_step(tag_from, tag_to, target_registry_name):
+#@ def _copy_between_registries_step(tag_from, tag_to, target_registry_name, docker_config_path):
 name: #@ "Push Image to {}".format(target_registry_name)
 uses: akhilerm/tag-push-action@v2.1.0
 with:
@@ -84,6 +84,8 @@ with:
 #      quay.io/user/app:1.0.0
 #      ghcr.io/user/app:latest
 #      ghcr.io/user/app:1.0.0
+  docker-config-path: #@ docker_config_path
+  #/home/myuser/.docker/config.json
 #@ end
 ---
 #@ def _setup_cosign():

--- a/.gflows/libs/job_docker_publish_alicloud.lib.yml
+++ b/.gflows/libs/job_docker_publish_alicloud.lib.yml
@@ -72,7 +72,7 @@ run: |
 - #@ steps.login_docker(sections.main_registry)
 #@   get_versions_tags_id = common.job_id(image_section,"alicloud-tags-")
 - #@ _get_versions(image_section, get_versions_tags_id, sections)
-- #@ bpsteps.copy_between_registries_step(tagging.image(sections.cache_registry, image_section),"${{ steps." + get_versions_tags_id + ".outputs.docker_image_ali_cloud_tags }}",sections.main_registry.name)
+- #@ bpsteps.copy_between_registries_step(tagging.image(sections.cache_registry, image_section),"${{ steps." + get_versions_tags_id + ".outputs.docker_image_ali_cloud_tags }}",sections.main_registry.name,sections.main_registry.docker_config_path)
 - #@ helmsteps.update_helmchart("${{ needs.version.outputs.app_version }}")
 - #@ bpsteps.setup_cosign()
 - #@ bpsteps.sign_container_with_cosign(tagging.with_registry(sections.main_registry.url,image_section.image_name,"${{ needs.version.outputs.app_version }}"), "${{ needs." + job.id.docker_build(image_section) + ".outputs.digest }}")

--- a/.gflows/libs/job_docker_publish_github.lib.yml
+++ b/.gflows/libs/job_docker_publish_github.lib.yml
@@ -66,7 +66,7 @@ run: |
 #@   get_versions_tags_id = common.job_id(image_section,"github-tags-")
 - #@ steps.checkout()
 - #@ _get_versions(image_section, get_versions_tags_id, sections)
-- #@ bpsteps.copy_between_registries_step(tagging.candidate_image(sections.cache_registry, image_section),"${{ steps." + get_versions_tags_id + ".outputs.docker_image_ghcr_tags }}",sections.cache_registry.name)
+- #@ bpsteps.copy_between_registries_step(tagging.candidate_image(sections.cache_registry, image_section),"${{ steps." + get_versions_tags_id + ".outputs.docker_image_ghcr_tags }}",sections.cache_registry.name,sections.cache_registry.docker_config_path)
 - #@ bpsteps.setup_cosign()
 - #@ bpsteps.sign_container_with_cosign(tagging.with_registry(sections.cache_registry.url,image_section.image_name,"${{ needs.version.outputs.app_version }}"), "${{ needs." + job.id.docker_build(image_section) + ".outputs.digest }}")
 #@ end

--- a/.gflows/libs/job_publish_nuget.lib.yml
+++ b/.gflows/libs/job_publish_nuget.lib.yml
@@ -12,6 +12,10 @@
   with:
     name: Nuget packages
     path: ./nuget
+- name: Setup Dotnet
+  uses: actions/setup-dotnet@v4
+  with:
+    dotnet-version: 7.x
 - name: Push generated package to GitHub registry
   run: dotnet nuget push ./nuget/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --source https://nuget.pkg.github.com/covergo/index.json
 - name: Push generated package symbols to GitHub registry

--- a/.gflows/libs/job_scan_code_net.lib.yml
+++ b/.gflows/libs/job_scan_code_net.lib.yml
@@ -45,6 +45,7 @@
       - name: SonarCloud Scan
         run: |
           dotnet tool install --global dotnet-sonarscanner
+          export PATH="$PATH:/root/.dotnet/tools"
           dotnet sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /o:covergo /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
           dotnet build --configuration Release
           dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.gflows/workflow-configuration/build-publish/settings.yml
+++ b/.gflows/workflow-configuration/build-publish/settings.yml
@@ -240,6 +240,7 @@ cache_registry:
   url: ghcr.io
   name: GitHub Container Registry
   user: ${{ github.repository_owner }}
+  docker_config_path: /home/runner/.docker/config.json
  # password: ${{ secrets.CR_PAT_FULL }}
 
 main_registry:
@@ -251,6 +252,7 @@ main_registry:
   #default
   branches:
     - main
+  docker_config_path: /home/runner/.docker/config.json
 
 scan_code_net:
   name: Sonar Code

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -79,6 +79,7 @@ jobs:
     - name: SonarCloud Scan
       run: |
         dotnet tool install --global dotnet-sonarscanner
+        export PATH="$PATH:/root/.dotnet/tools"
         dotnet sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /o:covergo /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
         dotnet build --configuration Release
         dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
@@ -182,6 +183,10 @@ jobs:
       with:
         name: Nuget packages
         path: ./nuget
+    - name: Setup Dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 7.x
     - name: Push generated package to GitHub registry
       run: dotnet nuget push ./nuget/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --source https://nuget.pkg.github.com/covergo/index.json
     - name: Push generated package symbols to GitHub registry
@@ -266,6 +271,10 @@ jobs:
       with:
         name: Nuget packages
         path: ./nuget
+    - name: Setup Dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 7.x
     - name: Push generated package to GitHub registry
       run: dotnet nuget push ./nuget/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --source https://nuget.pkg.github.com/covergo/index.json
     - name: Push generated package symbols to GitHub registry
@@ -955,6 +964,7 @@ jobs:
       with:
         src: ghcr.io/covergo/auth:candidate-${{ needs.version.outputs.app_version }}
         dst: ${{ steps.github-tags-auth-service.outputs.docker_image_ghcr_tags }}
+        docker-config-path: /home/runner/.docker/config.json
     - name: Set up sigstore cosign
       uses: sigstore/cosign-installer@main
     - name: Sign published container image
@@ -1020,6 +1030,7 @@ jobs:
       with:
         src: ghcr.io/covergo/auth:${{ needs.version.outputs.app_version }}
         dst: ${{ steps.alicloud-tags-auth-service.outputs.docker_image_ali_cloud_tags }}
+        docker-config-path: /home/runner/.docker/config.json
     - if: github.ref_type == 'tag'
       name: Publish helm chart
       uses: peter-evans/repository-dispatch@v2
@@ -1082,6 +1093,7 @@ jobs:
       with:
         src: ghcr.io/covergo/auth-predeployment:candidate-${{ needs.version.outputs.app_version }}
         dst: ${{ steps.github-tags-auth-predeployment.outputs.docker_image_ghcr_tags }}
+        docker-config-path: /home/runner/.docker/config.json
     - name: Set up sigstore cosign
       uses: sigstore/cosign-installer@main
     - name: Sign published container image
@@ -1147,6 +1159,7 @@ jobs:
       with:
         src: ghcr.io/covergo/auth-predeployment:${{ needs.version.outputs.app_version }}
         dst: ${{ steps.alicloud-tags-auth-predeployment.outputs.docker_image_ali_cloud_tags }}
+        docker-config-path: /home/runner/.docker/config.json
     - if: github.ref_type == 'tag'
       name: Publish helm chart
       uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
Some steps does not run properly on self-hosted runners, issues are related to dotnet installation and docker config file location. This PR fixes the issues making it work on any runner. 

`docker-config-path` is used only in push action so it's added there with the default option valid for Github-managed runners. The path could be different for self-hosted runners because of the user, currently we use root but we may redefine it later.