### PR TITLE
use Covergo ghcr.io image for buildx

### DIFF
--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -41,6 +41,7 @@ name: Set up Docker Buildx
 uses: docker/setup-buildx-action@v2
 with:
   version: v0.11.2
+  driver-opts: image=ghcr.io/covergo/buildkit:latest
 #@ end
 ---
 #@ def _checkout_private_actions():

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -120,6 +120,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -203,6 +204,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -292,6 +294,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -346,6 +349,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -403,6 +407,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -509,6 +514,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -629,6 +635,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -793,6 +800,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -1258,6 +1266,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
       with:
         version: v0.11.2
+        driver-opts: image=ghcr.io/covergo/buildkit:latest
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
We found out that Docker Hub introduces [pull limitations starting 1st of March 2025](https://docs.docker.com/docker-hub/usage/) which could impact the build-publish workflow. We already experience this problem with self-hosted runners so we can use AWS ECR official image instead. The image works, you can see it [here](https://github.com/CoverGo/Policies/actions/runs/13181922470/job/36794643516). 
![image](https://github.com/user-attachments/assets/624d52f6-b46c-43cf-8aa7-5d9ec0ee00c2)
