### PR TITLE
fix: remove deprecated cache action

### DIFF
--- a/.gflows/libs/integration-tests-legacy-steps.lib.yml
+++ b/.gflows/libs/integration-tests-legacy-steps.lib.yml
@@ -24,6 +24,13 @@
     image-under-test: #@ tagging.candidate_image(registry, environment.service_under_test.image)
 
 - uses: actions/cache@v4
+  with:
+    path: |
+      **/node_modules
+      **/.cache/yarn
+    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    restore-keys: |
+      ${{ runner.os }}-yarn-
 - name: Install yarn
   run: yarn install
 #@ for test_case in test_suites.tests:

--- a/.gflows/libs/integration-tests-legacy-steps.lib.yml
+++ b/.gflows/libs/integration-tests-legacy-steps.lib.yml
@@ -23,7 +23,6 @@
     service-under-test: #@ environment.service_under_test.name
     image-under-test: #@ tagging.candidate_image(registry, environment.service_under_test.image)
 
-- uses: c-hive/gha-yarn-cache@v2
 - name: Install yarn
   run: yarn install
 #@ for test_case in test_suites.tests:

--- a/.gflows/libs/integration-tests-legacy-steps.lib.yml
+++ b/.gflows/libs/integration-tests-legacy-steps.lib.yml
@@ -23,6 +23,7 @@
     service-under-test: #@ environment.service_under_test.name
     image-under-test: #@ tagging.candidate_image(registry, environment.service_under_test.image)
 
+- uses: actions/cache@v4
 - name: Install yarn
   run: yarn install
 #@ for test_case in test_suites.tests:


### PR DESCRIPTION
Sample failing runs due to deprecated:
- https://github.com/CoverGo/Products/actions/runs/14484963142/job/40628879699?pr=524#step:7:16
- https://github.com/CoverGo/Templates/actions/runs/14486535387/job/40633343510?pr=237

Successful run on products:
- https://github.com/CoverGo/Products/actions/runs/14485183028/job/40629492145

