### PR TITLE
CH-22814 update build-args to have npm tokens

### DIFF
--- a/.gflows/libs/steps.lib.yml
+++ b/.gflows/libs/steps.lib.yml
@@ -117,6 +117,8 @@ with:
   #@ build_args.append("GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}")
   #@ build_args.append("GH_ACCOUNT=${{ secrets.PAT_USER_READ_PACKAGES }}")
   #@ build_args.append("GH_TOKEN=${{ secrets.PAT_READ_PACKAGES }}")
+  #@ build_args.append("FORMKIT_ENTERPRISE_TOKEN=${{ secrets.FORMKIT_ENTERPRISE_TOKEN }}")
+  #@ build_args.append("COVERGO_NPM_TOKEN=${{ secrets.COVERGO_NPM_TOKEN }}")
   #@ if build_versioned_image:
   #@ build_args.append("BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}")
   #@ build_args.append("APP_VERSION=${{ needs.version.outputs.app_version }}")

--- a/github-sample/workflows/build-publish.yml
+++ b/github-sample/workflows/build-publish.yml
@@ -383,6 +383,8 @@ jobs:
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           GH_ACCOUNT=${{ secrets.PAT_USER_READ_PACKAGES }}
           GH_TOKEN=${{ secrets.PAT_READ_PACKAGES }}
+          FORMKIT_ENTERPRISE_TOKEN=${{ secrets.FORMKIT_ENTERPRISE_TOKEN }}
+          COVERGO_NPM_TOKEN=${{ secrets.COVERGO_NPM_TOKEN }}
           BUILD_DATETIME=${{ steps.meta.outputs.json && fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
           APP_VERSION=${{ needs.version.outputs.app_version }}
           FILE_VERSION=${{ needs.version.outputs.file_version }}


### PR DESCRIPTION
This pull request updates the token configuration for build and publish workflows by adding new environment variables for enterprise and npm tokens. These changes ensure the workflows can access additional secrets required for specific operations.

### Token configuration updates:

* [`.gflows/libs/steps.lib.yml`](diffhunk://#diff-948c33842360bed653b37e9efa94b5ec10f40cd98076213a7fe14f469e0d0157R120-R121): Added `FORMKIT_ENTERPRISE_TOKEN` and `COVERGO_NPM_TOKEN` as build arguments to support enterprise and npm-related operations.
* [`github-sample/workflows/build-publish.yml`](diffhunk://#diff-7b56bcf408a66ee9dddd84e1063f9c7d341ecc193e8c7baaf110f6ea333b4b40R386-R387): Added `FORMKIT_ENTERPRISE_TOKEN` and `COVERGO_NPM_TOKEN` as environment variables in the `jobs` section to make these tokens accessible during the build and publish process.